### PR TITLE
fix: packaging bug and utilize dt from config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["Eli Lifland <eli.d.lifland@gmail.com>"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.12"


### PR DESCRIPTION
The packaging bug was:

```
Installing the current project: forecasting-are (0.1.0)
Error: The current project could not be installed: No file/folder found for package forecasting-are
If you do not want to install the current project use --no-root.
If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
If you did intend to install the current project, you may need to set packages in your pyproject.toml file.
```